### PR TITLE
feat: add generic request method to HTTP utility

### DIFF
--- a/src/utils/http/index.ts
+++ b/src/utils/http/index.ts
@@ -102,6 +102,9 @@ const api = {
   },
   del<T>(config: AxiosRequestConfig): Promise<T> {
     return request({ ...config, method: 'DELETE' }) // DELETE 请求
+  },
+  request<T>(config: AxiosRequestConfig): Promise<T> {
+    return request({ ...config }) // 通用请求
   }
 }
 


### PR DESCRIPTION
feat: add generic request method to HTTP utility

Added a new generic request method to the API utility that allows for
making
any type of HTTP request by directly passing the Axios configuration
object.
This provides more flexibility for API calls that need custom
configurations
or use less common HTTP methods beyond the standard GET/POST/PUT/DELETE.

---

feat: 添加通用请求方法到 HTTP 工具

向 API 工具添加了新的通用请求方法，允许通过直接传递 Axios 配置对象来
发起任何类型的 HTTP 请求。这为需要自定义配置或使用标准 GET/POST/PUT/
feat: add generic request method to HTTP utility
DELETE
以外的 HTTP 方法的 API 调用提供了更大的灵活性。