### PR TITLE
style: 调整密码框支持切换显示隐藏、下移登录页滑块下方元素防止与报错文字重叠

### DIFF
--- a/src/views/auth/login/index.scss
+++ b/src/views/auth/login/index.scss
@@ -140,6 +140,7 @@
           justify-content: space-between;
           font-size: 14px;
           color: var(--art-text-gray-500);
+          margin-top: 10px;
 
           a {
             color: var(--main-color);

--- a/src/views/auth/login/index.vue
+++ b/src/views/auth/login/index.vue
@@ -65,6 +65,7 @@
                 type="password"
                 radius="8px"
                 autocomplete="off"
+                show-password
               />
             </ElFormItem>
             <div class="drag-verify">

--- a/src/views/auth/register/index.vue
+++ b/src/views/auth/register/index.vue
@@ -24,6 +24,7 @@
                 :placeholder="$t('register.placeholder[1]')"
                 type="password"
                 autocomplete="off"
+                show-password
               />
             </ElFormItem>
 
@@ -34,6 +35,7 @@
                 type="password"
                 autocomplete="off"
                 @keyup.enter="register"
+                show-password
               />
             </ElFormItem>
 

--- a/src/views/system/user-center/index.vue
+++ b/src/views/system/user-center/index.vue
@@ -109,15 +109,15 @@
 
           <ElForm :model="pwdForm" class="form" label-width="86px" label-position="top">
             <ElFormItem label="当前密码" prop="password">
-              <ElInput v-model="pwdForm.password" type="password" :disabled="!isEditPwd" />
+              <ElInput v-model="pwdForm.password" type="password" :disabled="!isEditPwd" show-password />
             </ElFormItem>
 
             <ElFormItem label="新密码" prop="newPassword">
-              <ElInput v-model="pwdForm.newPassword" type="password" :disabled="!isEditPwd" />
+              <ElInput v-model="pwdForm.newPassword" type="password" :disabled="!isEditPwd" show-password />
             </ElFormItem>
 
             <ElFormItem label="确认新密码" prop="confirmPassword">
-              <ElInput v-model="pwdForm.confirmPassword" type="password" :disabled="!isEditPwd" />
+              <ElInput v-model="pwdForm.confirmPassword" type="password" :disabled="!isEditPwd" show-password />
             </ElFormItem>
 
             <div class="el-form-item-right">


### PR DESCRIPTION
- 修改前
  > ![微信图片_2025-06-09_215018_148](https://github.com/user-attachments/assets/5dda3345-242a-4774-913c-bc40e5bca23b)

- 修改后
  > ![微信图片_2025-06-09_215107_103](https://github.com/user-attachments/assets/c3460766-2e31-4902-be5d-3bb9c8a94617)
