### PR TITLE
feat: 增加 ArtTable 组件的 customRender 属性

### DIFF
--- a/src/components/core/tables/art-table/index.vue
+++ b/src/components/core/tables/art-table/index.vue
@@ -26,7 +26,20 @@
               {{ col.label }}
             </slot>
           </template>
-          <template v-if="col.useSlot && col.prop" #default="slotScope">
+          <!-- 优先使用 customRender 函数 -->
+          <template v-if="col.customRender" #default="slotScope">
+            <component
+              :is="
+                col.customRender({
+                  ...slotScope,
+                  prop: col.prop,
+                  value: col.prop ? slotScope.row[col.prop] : undefined
+                })
+              "
+            />
+          </template>
+          <!-- 其次使用插槽 -->
+          <template v-else-if="col.useSlot && col.prop" #default="slotScope">
             <slot
               :name="col.slotName || col.prop"
               v-bind="{
@@ -227,6 +240,7 @@
     delete columnProps.headerSlotName
     delete columnProps.useSlot
     delete columnProps.slotName
+    delete columnProps.customRender
     return columnProps
   }
 

--- a/src/types/component/index.ts
+++ b/src/types/component/index.ts
@@ -2,7 +2,9 @@
  * 组件相关类型定义
  */
 
+import { Component, VNode } from 'vue'
 import { Option } from '../common'
+import { JSX } from 'vue/jsx-runtime'
 
 // 搜索组件类型
 export type SearchComponentType =
@@ -91,6 +93,12 @@ export interface ColumnOption<T = any> {
   useHeaderSlot?: boolean
   // 表头插槽名称（默认为 `${prop}-header`）
   headerSlotName?: string
+  /**
+   * 自定义渲染函数
+   * @param scope 当前单元格作用域数据
+   * @returns 渲染内容
+   */
+  customRender?: (scope: any) => VNode | JSX.Element | Component
   // 其他属性
   [key: string]: any
 }

--- a/src/views/examples/tables/basic.vue
+++ b/src/views/examples/tables/basic.vue
@@ -27,6 +27,7 @@
 <script setup lang="ts">
   import { useTable } from '@/composables/useTable'
   import { UserService } from '@/api/usersApi'
+  import { ElTag } from 'element-plus'
 
   defineOptions({ name: 'UserMixedUsageExample' })
 
@@ -63,6 +64,20 @@
           label: '性别',
           sortable: true,
           formatter: (row) => row.userGender || '未知'
+        },
+        {
+          prop: 'userGender_customRender',
+          label: '性别(customRender)',
+          sortable: true,
+          customRender: (scope) => {
+            return h(
+              ElTag,
+              {
+                type: scope.row.userGender === '男' ? 'success' : 'danger'
+              },
+              scope.row.userGender || '未知'
+            )
+          }
         },
         {
           prop: 'userPhone',


### PR DESCRIPTION
- 在 ColumnOption 接口中添加 customRender 属性，用于自定义单元格渲染 
- 在 ArtTable 组件中实现 customRender 的逻辑，优先使用 customRender 函数进行单元格渲染  #148 
- 添加示例，展示如何使用 customRender 属性自定义渲染单元格内容