### PR TITLE
fix: update scroll css

### DIFF
--- a/src/assets/styles/reset.scss
+++ b/src/assets/styles/reset.scss
@@ -118,19 +118,19 @@ blockquote:after {
 
 /*滚动条的轨道*/
 ::-webkit-scrollbar-track {
-  background-color: var(--art-text-gray-100);
+  background-color: transparent;
 }
 
 /*滚动条的滑块按钮*/
 ::-webkit-scrollbar-thumb {
   border-radius: 5px;
-  background-color: #cccccc !important;
+  background-color: #cccccc;
   transition: all 0.2s;
   -webkit-transition: all 0.2s;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background-color: #b0abab !important;
+  background-color: #b0abab;
 }
 
 /*滚动条的上下两端的按钮*/
@@ -141,10 +141,13 @@ blockquote:after {
 
 .dark {
   ::-webkit-scrollbar-track {
-    background-color: var(--art-bg-color);
+    background-color: transparent;
   }
 
   ::-webkit-scrollbar-thumb {
-    background-color: rgba(var(--art-gray-300-rgb), 0.8) !important;
+    background-color: rgba(255, 255, 255, 0.2);
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.4);
+    }
   }
 }


### PR DESCRIPTION
<img width="335" height="370" alt="image" src="https://github.com/user-attachments/assets/e42cc79f-87cd-4473-80ee-d7eebca7d313" />
<img width="401" height="481" alt="image" src="https://github.com/user-attachments/assets/a5bfd1e5-428e-4093-8b38-d64b71c80793" />

::-webkit-scrollbar与:root不在同一作用域，无法访问到变量

PR解决了上图问题，使滚动条与现有效果一致