### PR TITLE
fix: Table header move

### DIFF
--- a/src/components/core/tables/art-table-header/index.vue
+++ b/src/components/core/tables/art-table-header/index.vue
@@ -57,6 +57,7 @@
             :disabled="false"
             filter=".fixed-column"
             :prevent-on-filter="false"
+            @move="checkColumnMove"
           >
             <div
               v-for="item in columns"
@@ -170,6 +171,21 @@
    */
   const shouldShow = (componentName: string) => {
     return layoutItems.value.includes(componentName)
+  }
+
+  /**
+   * 拖拽移动事件处理 - 防止固定列位置改变
+   * @param evt move事件对象
+   * @returns 是否允许移动
+   */
+  const checkColumnMove = (event: any) => {
+    // 拖拽进入的目标 DOM 元素
+    const toElement = event.related as HTMLElement
+    // 如果目标位置是 fixed 列，则不允许移动
+    if (toElement && toElement.classList.contains('fixed-column')) {
+      return false
+    }
+    return true
   }
 
   /** 搜索事件处理 */


### PR DESCRIPTION
问题：
- 改变列排序时，固定列会被其他列影响，导致列排序与表格列顺序不符
<img width="694" height="574" alt="image" src="https://github.com/user-attachments/assets/0dd7b031-d05c-4693-a3d4-380098dabec6" />

解决方案：
- 添加拖拽移动事件处理函数，在拖拽事件中判断目标元素是否为固定列，是则禁止移动