### PR TITLE
fix: 表单中标题多行文本因行高导致行距异常，调整间距修复显示问题

### DIFF
--- a/src/assets/styles/el-ui.scss
+++ b/src/assets/styles/el-ui.scss
@@ -29,7 +29,8 @@
 // 优化 el-form-item 标签高度
 .el-form-item__label {
   height: var(--el-component-custom-height) !important;
-  line-height: var(--el-component-custom-height) !important;
+  align-items: center !important;
+  line-height: 1.2 !important;
 }
 
 // 日期选择器


### PR DESCRIPTION
<img width="2880" height="1478" alt="QQ图片20251105171328" src="https://github.com/user-attachments/assets/bf21a40d-c00c-49f8-955d-61839e719ffa" />
标题为两行的情况行距过高，修改结果如下
<img width="2876" height="607" alt="QQ图片20251105171348" src="https://github.com/user-attachments/assets/6f869bbb-aa40-47db-b186-6745d2629a2c" />
