### PR TITLE
fix(lock-screen): prevent browser autofill on password inputs

### DIFF
--- a/src/components/core/layouts/art-screen-lock/index.vue
+++ b/src/components/core/layouts/art-screen-lock/index.vue
@@ -36,6 +36,7 @@
                 type="password"
                 :placeholder="$t('lockScreen.lock.inputPlaceholder')"
                 :show-password="true"
+                autocomplete="new-password"
                 ref="lockInputRef"
                 class="w-full mt-9"
                 @keyup.enter="handleLock"
@@ -75,6 +76,7 @@
               type="password"
               :placeholder="$t('lockScreen.unlock.inputPlaceholder')"
               :show-password="true"
+              autocomplete="new-password"
               ref="unlockInputRef"
               class="mt-5"
             >


### PR DESCRIPTION
## 简介
为锁屏组件中的两处密码输入框补充 `autocomplete="new-password"` 属性，避免浏览器将其误识别为登录密码框并自动填充。

## 关联 Issue
Close #248