### PR TITLE
feat(form): add dynamic form example for issue #243

### DIFF
--- a/src/components/core/forms/DynamicForm.vue
+++ b/src/components/core/forms/DynamicForm.vue
@@ -1,0 +1,167 @@
+<template>
+  <ElForm
+    ref="innerForm"
+    :model="model"
+    :rules="rules"
+    label-width="120px"
+    :label-position="labelPosition"
+  >
+    <template v-for="(item, idx) in items" :key="item.key || idx">
+      <ElFormItem :label="item.label" :prop="item.key">
+        <component
+          v-if="item.type === 'input'"
+          :is="ElInput"
+          v-model="model[item.key]"
+          v-bind="item.props"
+        />
+
+        <component
+          v-else-if="item.type === 'select'"
+          :is="ElSelect"
+          v-model="model[item.key]"
+          v-bind="item.props"
+        >
+          <ElOption
+            v-for="opt in item.props?.options || []"
+            :key="opt.value"
+            :label="opt.label"
+            :value="opt.value"
+          />
+        </component>
+
+        <component
+          v-else-if="item.type === 'date'"
+          :is="ElDatePicker"
+          v-model="model[item.key]"
+          type="date"
+          v-bind="item.props"
+        />
+
+        <component
+          v-else-if="item.type === 'upload'"
+          :is="ElUpload"
+          v-model:modelValue="model[item.key]"
+          v-bind="item.props"
+        >
+          <ElButton size="small" type="primary">上传</ElButton>
+        </component>
+
+        <component
+          v-else-if="item.type === 'radio'"
+          :is="ElRadioGroup"
+          v-model="model[item.key]"
+          v-bind="item.props"
+        >
+          <ElRadio v-for="opt in item.props?.options || []" :key="opt.value" :label="opt.value">{{
+            opt.label
+          }}</ElRadio>
+        </component>
+
+        <component
+          v-else-if="item.type === 'checkbox'"
+          :is="ElCheckboxGroup"
+          v-model="model[item.key]"
+          v-bind="item.props"
+        >
+          <ElCheckbox
+            v-for="opt in item.props?.options || []"
+            :key="opt.value"
+            :label="opt.value"
+            >{{ opt.label }}</ElCheckbox
+          >
+        </component>
+
+        <div v-else>不支持的字段类型: {{ item.type }}</div>
+      </ElFormItem>
+    </template>
+
+    <div class="mt-4">
+      <ElButton type="primary" @click="submit">提交</ElButton>
+      <ElButton @click="reset" class="ml-2">重置</ElButton>
+    </div>
+  </ElForm>
+</template>
+
+<script setup lang="ts">
+  import { reactive, watch, ref } from 'vue'
+  import {
+    ElForm,
+    ElFormItem,
+    ElInput,
+    ElSelect,
+    ElOption,
+    ElDatePicker,
+    ElUpload,
+    ElButton,
+    ElRadioGroup,
+    ElRadio,
+    ElCheckboxGroup,
+    ElCheckbox
+  } from 'element-plus'
+
+  interface FieldItem {
+    label: string
+    key: string
+    type: 'input' | 'select' | 'date' | 'upload' | 'radio' | 'checkbox' | string
+    props?: Record<string, any>
+  }
+
+  const props = defineProps<{
+    modelValue?: Record<string, any>
+    items: FieldItem[]
+    rules?: Record<string, any>
+    labelPosition?: 'left' | 'right' | 'top'
+  }>()
+
+  const emit = defineEmits(['update:modelValue', 'submit'])
+
+  const items = props.items || []
+  const rules = props.rules || {}
+  const labelPosition = props.labelPosition || 'right'
+
+  const model = reactive<Record<string, any>>(props.modelValue || {})
+
+  watch(
+    () => props.modelValue,
+    (v: Record<string, any> | undefined) => {
+      if (v) {
+        Object.assign(model, v)
+      }
+    },
+    { deep: true }
+  )
+
+  watch(
+    model,
+    (v: Record<string, any>) => {
+      emit('update:modelValue', { ...v })
+    },
+    { deep: true }
+  )
+
+  const innerForm = ref()
+
+  const submit = async () => {
+    if (!innerForm.value) return
+    try {
+      await innerForm.value.validate()
+      emit('submit', { ...model })
+    } catch {
+      // validation failed
+    }
+  }
+
+  const reset = () => {
+    if (innerForm.value) innerForm.value.resetFields()
+  }
+</script>
+
+<style scoped>
+  .ml-2 {
+    margin-left: 8px;
+  }
+
+  .mt-4 {
+    margin-top: 16px;
+  }
+</style>

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -277,7 +277,10 @@
       "tablesBasic": "Basic Tables",
       "tables": "Advanced Tables",
       "tablesTree": "Tree Table Layout",
-      "forms": "Forms",
+      "forms": {
+        "title": "Forms",
+        "dynamicForm": "Dynamic Form"
+      },
       "searchBar": "Search Form",
       "socketChat": "Socket Connection",
       "permission": {

--- a/src/locales/langs/zh.json
+++ b/src/locales/langs/zh.json
@@ -277,7 +277,10 @@
       "tablesBasic": "基础表格",
       "tables": "高级表格",
       "tablesTree": "左右布局表格",
-      "forms": "表单",
+      "forms": {
+        "title": "表单",
+        "dynamicForm": "动态表单"
+      },
       "searchBar": "搜索表单",
       "socketChat": "Socket 连接",
       "permission": {

--- a/src/router/modules/examples.ts
+++ b/src/router/modules/examples.ts
@@ -95,7 +95,7 @@ export const examplesRoutes: AppRouteRecord = {
       name: 'Forms',
       component: '/examples/forms',
       meta: {
-        title: 'menus.examples.forms',
+        title: 'menus.examples.forms.title',
         icon: 'ri:table-view',
         keepAlive: true
       }
@@ -107,6 +107,16 @@ export const examplesRoutes: AppRouteRecord = {
       meta: {
         title: 'menus.examples.searchBar',
         icon: 'ri:table-line',
+        keepAlive: true
+      }
+    },
+    {
+      path: 'form/dynamic-form',
+      name: 'DynamicFormExample',
+      component: '/examples/forms/dynamic-form',
+      meta: {
+        title: 'menus.examples.forms.dynamicForm',
+        icon: 'ri:list-settings-line',
         keepAlive: true
       }
     },

--- a/src/views/examples/forms/dynamic-form.vue
+++ b/src/views/examples/forms/dynamic-form.vue
@@ -1,0 +1,199 @@
+<template>
+  <div class="pb-5">
+    <h2 class="mb-2 text-lg font-medium">动态表单示例</h2>
+
+    <ElRow :gutter="20">
+      <ElCol :span="8">
+        <ElCard shadow="never" class="art-card p-4">
+          <h3 class="mb-3">添加字段</h3>
+          <ElForm :model="fieldForm" label-width="80px">
+            <ElFormItem label="字段标签">
+              <ElInput v-model="fieldForm.label" placeholder="例如：用户名" />
+            </ElFormItem>
+            <ElFormItem label="字段 key">
+              <ElInput v-model="fieldForm.key" placeholder="例如：name" />
+            </ElFormItem>
+            <ElFormItem label="字段类型">
+              <ElSelect v-model="fieldForm.type" placeholder="请选择类型">
+                <ElOption label="输入框" value="input" />
+                <ElOption label="下拉" value="select" />
+                <ElOption label="日期" value="date" />
+                <ElOption label="上传" value="upload" />
+                <ElOption label="单选" value="radio" />
+                <ElOption label="多选" value="checkbox" />
+              </ElSelect>
+            </ElFormItem>
+            <ElFormItem label="选项(逗号分隔)">
+              <ElInput v-model="fieldForm.options" placeholder="仅 select/radio/checkbox 使用" />
+            </ElFormItem>
+            <ElFormItem>
+              <ElButton type="primary" @click="addField">添加字段</ElButton>
+              <ElButton class="ml-2" @click="resetFieldForm">重置</ElButton>
+            </ElFormItem>
+          </ElForm>
+
+          <h3 class="mt-4 mb-2">已添加字段</h3>
+          <div class="h-64 overflow-auto">
+            <div v-for="(it, i) in items" :key="it.key" class="p-2 border-b">
+              <div class="flex justify-between items-center">
+                <div>
+                  <div class="font-medium"
+                    >{{ it.label }} <span class="text-sm text-gray-500">({{ it.type }})</span></div
+                  >
+                  <div class="text-sm text-gray-400">key: {{ it.key }}</div>
+                </div>
+                <div>
+                  <ElButton size="small" type="danger" @click="removeField(i)">删除</ElButton>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ElCard>
+      </ElCol>
+
+      <ElCol :span="16">
+        <ElCard shadow="never" class="art-card p-4">
+          <h3 class="mb-3">表单预览</h3>
+          <DynamicForm v-model="formData" :items="items" :rules="rules" @submit="onSubmit" />
+
+          <div class="art-card p-4 mt-4">
+            <h4 class="mb-2">表单数据 (实时)</h4>
+            <pre><code>{{ formData }}</code></pre>
+          </div>
+        </ElCard>
+      </ElCol>
+    </ElRow>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref, reactive } from 'vue'
+  import DynamicForm from '@/components/core/forms/DynamicForm.vue'
+  import { ElMessage } from 'element-plus'
+
+  interface FieldItem {
+    label: string
+    key: string
+    type: string
+    props?: Record<string, any>
+  }
+
+  const items = ref<FieldItem[]>([
+    { label: '用户名', key: 'name', type: 'input' },
+    {
+      label: '用户等级',
+      key: 'level',
+      type: 'select',
+      props: {
+        options: [
+          { label: '普通', value: 'normal' },
+          { label: 'VIP', value: 'vip' }
+        ]
+      }
+    }
+  ])
+
+  const formData = ref<Record<string, any>>({})
+
+  const fieldForm = reactive({ label: '', key: '', type: 'input', options: '' })
+
+  const rules = {
+    name: [{ required: true, message: '请输入用户名', trigger: 'blur' }]
+  }
+
+  const addField = () => {
+    if (!fieldForm.label || !fieldForm.key) {
+      ElMessage.warning('请填写字段标签和 key')
+      return
+    }
+    const exists = items.value.find((i: FieldItem) => i.key === fieldForm.key)
+    if (exists) {
+      ElMessage.error('该 key 已存在，请换一个')
+      return
+    }
+
+    const newItem: FieldItem = {
+      label: fieldForm.label,
+      key: fieldForm.key,
+      type: fieldForm.type,
+      props: {}
+    }
+
+    if (['select', 'radio', 'checkbox'].includes(fieldForm.type) && fieldForm.options) {
+      const opts = fieldForm.options
+        .split(',')
+        .map((s: string) => s.trim())
+        .filter(Boolean)
+      newItem.props = { options: opts.map((v: string) => ({ label: v, value: v })) }
+    }
+
+    if (fieldForm.type === 'upload') {
+      newItem.props = { multiple: false }
+    }
+
+    items.value.push(newItem)
+    // init value
+    formData.value[fieldForm.key] = fieldForm.type === 'checkbox' ? [] : undefined
+    resetFieldForm()
+  }
+
+  const resetFieldForm = () => {
+    fieldForm.label = ''
+    fieldForm.key = ''
+    fieldForm.type = 'input'
+    fieldForm.options = ''
+  }
+
+  const removeField = (index: number) => {
+    const key = items.value[index].key
+    items.value.splice(index, 1)
+    delete formData.value[key]
+  }
+
+  const onSubmit = (data: Record<string, any>) => {
+    ElMessage.success('提交成功，请查看控制台或右侧数据')
+    console.log('动态表单提交：', data)
+  }
+</script>
+
+<style scoped>
+  .ml-2 {
+    margin-left: 8px;
+  }
+
+  .pb-5 {
+    padding-bottom: 20px;
+  }
+
+  .h-64 {
+    height: 16rem;
+  }
+
+  .flex {
+    display: flex;
+  }
+
+  .justify-between {
+    justify-content: space-between;
+  }
+
+  .items-center {
+    align-items: center;
+  }
+
+  .font-medium {
+    font-weight: 500;
+  }
+
+  .text-sm {
+    font-size: 0.875rem;
+  }
+
+  .text-gray-500 {
+    color: #6b7280;
+  }
+
+  .text-gray-400 {
+    color: #9ca3af;
+  }
+</style>


### PR DESCRIPTION
# feat: 新增动态表单组件及示例页面

## 📝 描述

本 PR 旨在解决 #243 需求，新增了一个通用的动态表单组件 `DynamicForm`，并提供了相应的示例页面。该组件支持通过配置动态渲染表单项，适用于需要灵活配置表单字段的业务场景。

## ✨ 主要变更

### 1. 新增组件 `DynamicForm`
- 位置：`src/components/core/forms/DynamicForm.vue`
- 功能：
  - 支持多种字段类型渲染：Input, Select, DatePicker, Upload, Radio, Checkbox。
  - 支持表单验证（Rules）。
  - 支持双向数据绑定（v-model）。
  - 提供提交（submit）和重置（reset）事件。

### 2. 新增示例页面
- 位置：`src/views/examples/forms/dynamic-form.vue`
- 功能：
  - 提供可视化界面动态添加/删除表单字段。
  - 实时预览表单渲染效果及数据变化。
  - 演示了组件的基本用法和配置方式。

### 3. 路由与菜单
- 在 `src/router/modules/examples.ts` 中注册了新路由 `/examples/form/dynamic-form`。
- 添加了对应的国际化配置（中/英），菜单名称为 "动态表单" / "Dynamic Form"。
- 菜单图标配置为 `ri:list-settings-line`。

### 4. 其他优化
- 修复了相关文件的 ESLint 和 TypeScript 类型错误。

## 🔗 关联 Issue

- Closes #243

## 📸 截图 
<img width="2878" height="1410" alt="image" src="https://github.com/user-attachments/assets/040a297c-d3a9-4785-a5be-ab931579e225" />


## ✅ 检查清单

- [x] 代码符合项目的 ESLint/Prettier 规范
- [x] 已添加必要的国际化配置
- [x] 本地运行无 TypeScript 编译错误
# feat: 新增动态表单组件及示例页面

