### PR TITLE
fix: 解决菜单超高无法滚动问题

### DIFF
--- a/src/components/core/layouts/art-menus/art-sidebar-menu/index.vue
+++ b/src/components/core/layouts/art-menus/art-sidebar-menu/index.vue
@@ -66,28 +66,27 @@
       :class="`menu-left-${getMenuTheme.theme} menu-left-${!menuOpen ? 'close' : 'open'}`"
       :style="{ background: getMenuTheme.background }"
     >
-      <ElScrollbar :style="scrollbarStyle">
-        <!-- Logo、系统名称 -->
-        <div
-          class="header"
-          @click="navigateToHome"
+      <!-- Logo、系统名称 -->
+      <div
+        class="header"
+        @click="navigateToHome"
+        :style="{
+          background: getMenuTheme.background
+        }"
+      >
+        <ArtLogo v-if="!isDualMenu" class="logo" />
+
+        <p
+          :class="{ 'is-dual-menu-name': isDualMenu }"
           :style="{
-            background: getMenuTheme.background
+            color: getMenuTheme.systemNameColor,
+            opacity: !menuOpen ? 0 : 1
           }"
         >
-          <ArtLogo v-if="!isDualMenu" class="logo" />
-
-          <p
-            :class="{ 'is-dual-menu-name': isDualMenu }"
-            :style="{
-              color: getMenuTheme.systemNameColor,
-              opacity: !menuOpen ? 0 : 1
-            }"
-          >
-            {{ AppConfig.systemInfo.name }}
-          </p>
-        </div>
-
+          {{ AppConfig.systemInfo.name }}
+        </p>
+      </div>
+      <ElScrollbar :style="scrollbarStyle">
         <ElMenu
           :class="'el-menu-' + getMenuTheme.theme"
           :collapse="!menuOpen"
@@ -214,7 +213,7 @@
     const isCollapsed = isDualMenu.value && !menuOpen.value
     return {
       transform: isCollapsed ? 'translateY(-50px)' : 'translateY(0)',
-      height: isCollapsed ? 'calc(100% + 50px)' : '100%',
+      height: isCollapsed ? 'calc(100% + 50px)' : 'calc(100% - 60px)',
       transition: 'transform 0.3s ease'
     }
   })

--- a/src/components/core/layouts/art-menus/art-sidebar-menu/style.scss
+++ b/src/components/core/layouts/art-menus/art-sidebar-menu/style.scss
@@ -170,8 +170,6 @@
 
   .el-menu {
     box-sizing: border-box;
-    height: calc(100vh - 60px);
-    overflow-y: auto;
     // 防止菜单内的滚动影响整个页面滚动
     overscroll-behavior: contain;
     border-right: 0;


### PR DESCRIPTION
修复 el-menu 菜单超过页面高度鼠标滚轮无法问题（包括垂直模式和双列模式）。 修复 system.name 超出页面高度跟随滚动问题，现在固定在 subMenu 上方（包含垂直模式和双列模式）。