### PR TITLE
refactor: 将 ElCard shadow 配置提取到全局配置

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,12 @@
 <template>
-  <ElConfigProvider size="default" :locale="locales[language]" :z-index="3000">
+  <ElConfigProvider
+    size="default"
+    :locale="locales[language]"
+    :z-index="3000"
+    :card="{
+      shadow: 'never'
+    }"
+  >
     <RouterView></RouterView>
   </ElConfigProvider>
 </template>

--- a/src/views/examples/forms/index.vue
+++ b/src/views/examples/forms/index.vue
@@ -3,7 +3,7 @@
   <div class="pb-5">
     <h2 class="mb-1 text-lg font-medium">表单组件示例</h2>
 
-    <ElCard shadow="never" class="art-card-xs">
+    <ElCard class="art-card-xs">
       <ArtForm
         ref="formRef"
         v-model="formData"

--- a/src/views/examples/permission/button-auth/index.vue
+++ b/src/views/examples/permission/button-auth/index.vue
@@ -10,7 +10,7 @@
     </div>
 
     <div class="mb-6">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="flex-cb font-semibold">
             <span class="flex-1">当前用户权限信息</span>
@@ -46,7 +46,7 @@
 
     <!-- 基于角色的权限控制演示 -->
     <div class="mb-6 last:mb-0">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="flex-cb font-semibold">
             <span class="flex-1">基于角色的权限控制（v-roles 指令）</span>
@@ -104,7 +104,7 @@
 
     <!-- 后端模式：基于路由权限配置的控制演示 -->
     <div class="mb-6 last:mb-0">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="flex-cb font-semibold">
             <span class="flex-1">后端模式权限控制（v-auth 指令）</span>
@@ -197,7 +197,7 @@
 
     <!-- 前端模式：编程式权限控制演示 -->
     <div class="mb-6 last:mb-0">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="flex-cb font-semibold">
             <span class="flex-1">前端模式权限控制（hasAuth 方法）</span>
@@ -293,7 +293,7 @@
 
     <!-- 后端模式：编程式权限控制演示 -->
     <div class="mb-6 last:mb-0">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="flex-cb font-semibold">
             <span class="flex-1">后端模式权限控制（hasAuth 方法）</span>
@@ -387,7 +387,7 @@
 
     <!-- 权限模式对比说明 -->
     <div class="mb-6 last:mb-0">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="flex-cb font-semibold">
             <span class="flex-1">权限控制模式对比</span>

--- a/src/views/examples/permission/page-visibility/index.vue
+++ b/src/views/examples/permission/page-visibility/index.vue
@@ -13,7 +13,7 @@
     </div>
 
     <div class="mb-6">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="flex-c gap-2 font-semibold">
             <span>权限验证成功</span>
@@ -38,7 +38,7 @@
 
     <!-- 页面级权限控制说明 -->
     <div class="mb-6 last:mb-0">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="flex-c font-semibold">
             <span>页面级权限控制说明</span>
@@ -47,7 +47,7 @@
         <div>
           <ElTimeline>
             <ElTimelineItem timestamp="前端控制模式" type="primary" size="large">
-              <ElCard shadow="never">
+              <ElCard>
                 <h4 class="m-0 mb-2 text-base font-semibold">基于角色的权限控制</h4>
                 <p class="m-0 mb-2 leading-[1.6] text-g-700">
                   在前端控制模式下，页面访问权限由路由配置文件中的
@@ -93,7 +93,7 @@
             </ElTimelineItem>
 
             <ElTimelineItem timestamp="后端控制模式" type="warning" size="large">
-              <ElCard shadow="never">
+              <ElCard>
                 <h4 class="m-0 mb-2 text-base font-semibold">基于菜单接口的权限控制</h4>
                 <p class="m-0 mb-2 leading-[1.6] text-g-700"
                   >在后端控制模式下，页面访问权限由后端统一管理，前端通过解析后端接口返回的菜单列表来生成可访问的路由，从而实现权限控制</p
@@ -142,7 +142,7 @@
             </ElTimelineItem>
 
             <ElTimelineItem timestamp="菜单显示控制" type="success" size="large">
-              <ElCard shadow="never">
+              <ElCard>
                 <h4>侧边栏菜单可见性</h4>
                 <p><strong>前端控制模式：</strong></p>
                 <ul>
@@ -165,7 +165,7 @@
 
     <!-- 权限控制最佳实践 -->
     <div class="best-practices">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="card-header">
             <span>权限控制最佳实践</span>

--- a/src/views/examples/permission/switch-role/index.vue
+++ b/src/views/examples/permission/switch-role/index.vue
@@ -11,7 +11,7 @@
 
     <!-- 当前用户信息 -->
     <div class="mb-6">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="font-semibold">
             <span>当前登录用户</span>
@@ -45,7 +45,7 @@
 
     <!-- 用户角色切换 -->
     <div class="mb-6">
-      <ElCard shadow="never" class="art-card-xs">
+      <ElCard class="art-card-xs">
         <template #header>
           <div class="font-semibold">
             <span>账号切换</span>

--- a/src/views/examples/socket-chat/index.vue
+++ b/src/views/examples/socket-chat/index.vue
@@ -10,7 +10,7 @@
     <!-- 连接状态和统计信息 -->
     <ElRow :gutter="20" class="mb-15">
       <ElCol :xs="24" :sm="12" :md="8">
-        <ElCard class="h-full border-0" :body-style="{ padding: '20px' }" shadow="never">
+        <ElCard class="h-full border-0" :body-style="{ padding: '20px' }">
           <div class="text-center">
             <div class="text-2xl font-bold text-blue-500 mb-1">{{ messageCount }}</div>
             <div class="text-sm font-medium text-gray-900 mb-1">消息统计</div>
@@ -19,7 +19,7 @@
         </ElCard>
       </ElCol>
       <ElCol :xs="24" :sm="12" :md="8">
-        <ElCard class="h-full border-0" :body-style="{ padding: '20px' }" shadow="never">
+        <ElCard class="h-full border-0" :body-style="{ padding: '20px' }">
           <div class="text-center">
             <ElTag :type="connectionTagType" size="large" class="mb-2">
               {{ wsClient?.connectionStatusText || '未连接' }}
@@ -30,7 +30,7 @@
         </ElCard>
       </ElCol>
       <ElCol :xs="24" :sm="12" :md="8">
-        <ElCard class="h-full border-0" :body-style="{ padding: '20px' }" shadow="never">
+        <ElCard class="h-full border-0" :body-style="{ padding: '20px' }">
           <div class="text-center">
             <div class="text-2xl font-bold text-amber-500 mb-1">{{ reconnectCount }}</div>
             <div class="text-sm font-medium text-gray-900 mb-1">重连次数</div>
@@ -43,7 +43,7 @@
     <!-- 连接配置和发送消息 -->
     <ElRow :gutter="20" class="mb-15">
       <ElCol :xs="24" :md="12">
-        <ElCard class="h-full border-0" shadow="never">
+        <ElCard class="h-full border-0">
           <template #header>
             <div class="flex items-center justify-between">
               <span class="text-base font-bold">连接配置</span>
@@ -84,7 +84,7 @@
       </ElCol>
 
       <ElCol :xs="24" :md="12">
-        <ElCard class="h-full border-0" shadow="never">
+        <ElCard class="h-full border-0">
           <template #header>
             <span class="text-base font-bold">发送消息</span>
           </template>
@@ -125,7 +125,7 @@
     <!-- 接收消息 - 单独占一行 -->
     <ElRow class="mb-15">
       <ElCol :span="24">
-        <ElCard class="border-0" shadow="never">
+        <ElCard class="border-0">
           <template #header>
             <div class="flex items-center justify-between">
               <span class="text-base font-bold">接收消息</span>
@@ -151,7 +151,7 @@
     </ElRow>
 
     <!-- 连接日志 -->
-    <ElCard class="border-0" shadow="never">
+    <ElCard class="border-0">
       <template #header>
         <div class="flex items-center justify-between">
           <span class="text-base font-bold">连接日志</span>

--- a/src/views/examples/tables/basic.vue
+++ b/src/views/examples/tables/basic.vue
@@ -1,7 +1,7 @@
 <!-- 基础表格 -->
 <template>
   <div class="user-page art-full-height">
-    <ElCard class="art-table-card" shadow="never" style="margin-top: 0">
+    <ElCard class="art-table-card" style="margin-top: 0">
       <!-- 表格 -->
       <ArtTable
         rowKey="id"

--- a/src/views/examples/tables/index.vue
+++ b/src/views/examples/tables/index.vue
@@ -3,7 +3,7 @@
 <template>
   <div class="flex flex-col gap-4 pb-5">
     <!-- 功能介绍卡片 -->
-    <ElCard shadow="never" class="art-card-xs">
+    <ElCard class="art-card-xs">
       <template #header>
         <div class="flex-wrap gap-3 flex-cb">
           <h3 class="m-0">高级表格完整能力展示</h3>
@@ -139,7 +139,7 @@
     />
 
     <!-- 表格区域 -->
-    <ElCard class="flex-1 art-table-card" shadow="never" style="margin-top: 0">
+    <ElCard class="flex-1 art-table-card" style="margin-top: 0">
       <template #header>
         <div class="flex-cb">
           <h4 class="m-0">用户数据表格</h4>
@@ -321,7 +321,7 @@
     </ElCard>
 
     <!-- 高级功能演示 -->
-    <ElCard shadow="never" class="art-card-xs">
+    <ElCard class="art-card-xs">
       <template #header>
         <h4 class="m-0">高级功能演示</h4>
       </template>
@@ -384,7 +384,7 @@
     </ElCard>
 
     <!-- 缓存刷新策略演示 -->
-    <ElCard shadow="never" class="art-card-xs">
+    <ElCard class="art-card-xs">
       <template #header>
         <h4 class="m-0">缓存刷新策略演示</h4>
       </template>

--- a/src/views/examples/tables/tree.vue
+++ b/src/views/examples/tables/tree.vue
@@ -3,7 +3,7 @@
   <div class="art-full-height">
     <div class="box-border flex gap-4 h-full max-md:block max-md:gap-0 max-md:h-auto">
       <div class="flex-shrink-0 w-58 h-full max-md:w-full max-md:h-auto max-md:mb-5">
-        <ElCard class="tree-card art-card-xs flex flex-col h-full mt-0" shadow="never">
+        <ElCard class="tree-card art-card-xs flex flex-col h-full mt-0">
           <template #header>
             <b>分类树</b>
           </template>
@@ -23,7 +23,7 @@
       <div class="flex flex-col flex-grow min-w-0">
         <UserSearch v-model="defaultFilter" />
 
-        <ElCard class="flex flex-col flex-1 min-h-0 art-table-card" shadow="never">
+        <ElCard class="flex flex-col flex-1 min-h-0 art-table-card">
           <ArtTableHeader v-model:columns="columnChecks" :loading="loading" @refresh="refreshData">
             <template #left>
               <ElSpace wrap>

--- a/src/views/examples/tabs/index.vue
+++ b/src/views/examples/tabs/index.vue
@@ -4,7 +4,7 @@
     <h3 class="mb-5 text-xl font-normal">标签页操作</h3>
 
     <!-- 修改标签标题模块 -->
-    <ElCard class="mb-7.5" header="修改标签标题" shadow="never">
+    <ElCard class="mb-7.5" header="修改标签标题">
       <div class="flex gap-2">
         <ElInput
           v-model="newTabTitle"
@@ -21,7 +21,7 @@
     </ElCard>
 
     <!-- 获取标签页模块 -->
-    <ElCard class="mb-7.5" header="获取标签页信息" shadow="never">
+    <ElCard class="mb-7.5" header="获取标签页信息">
       <div class="mb-4">
         <p class="m-0 mb-2 text-sm text-g-600"> 当前标签页信息：{{ currentTab }} </p>
       </div>
@@ -35,7 +35,7 @@
     </ElCard>
 
     <!-- 关闭标签页模块 -->
-    <ElCard class="mb-7.5" header="关闭标签页" shadow="never">
+    <ElCard class="mb-7.5" header="关闭标签页">
       <ElRow :gutter="20">
         <ElCol :span="24">
           <ElButton type="danger" plain @click="handleCloseTab(routePath)"> 关闭当前标签 </ElButton>

--- a/src/views/system/menu/index.vue
+++ b/src/views/system/menu/index.vue
@@ -10,7 +10,7 @@
       @search="handleSearch"
     />
 
-    <ElCard class="art-table-card" shadow="never">
+    <ElCard class="art-table-card">
       <!-- 表格头部 -->
       <ArtTableHeader
         :showZebra="false"

--- a/src/views/system/role/index.vue
+++ b/src/views/system/role/index.vue
@@ -8,11 +8,7 @@
       @reset="resetSearchParams"
     ></RoleSearch>
 
-    <ElCard
-      class="art-table-card"
-      shadow="never"
-      :style="{ 'margin-top': showSearchBar ? '12px' : '0' }"
-    >
+    <ElCard class="art-table-card" :style="{ 'margin-top': showSearchBar ? '12px' : '0' }">
       <ArtTableHeader
         v-model:columns="columnChecks"
         v-model:showSearchBar="showSearchBar"

--- a/src/views/system/user/index.vue
+++ b/src/views/system/user/index.vue
@@ -8,7 +8,7 @@
     <!-- 搜索栏 -->
     <UserSearch v-model="searchForm" @search="handleSearch" @reset="resetSearchParams"></UserSearch>
 
-    <ElCard class="art-table-card" shadow="never">
+    <ElCard class="art-table-card">
       <!-- 表格头部 -->
       <ArtTableHeader v-model:columns="columnChecks" :loading="loading" @refresh="refreshData">
         <template #left>

--- a/src/views/template/pricing/index.vue
+++ b/src/views/template/pricing/index.vue
@@ -16,7 +16,7 @@
     <div class="mt-20 max-md:mt-0">
       <ElRow :gutter="20" justify="center">
         <ElCol v-for="plan in pricingPlans" :key="plan.type" :xs="24" :sm="12" :md="6" class="mb-5">
-          <ElCard class="flex flex-col h-full rounded-xl" shadow="never">
+          <ElCard class="flex flex-col h-full rounded-xl">
             <div class="mb-5">
               <h3 class="mb-2.5 text-xl font-medium">{{ plan.title }}</h3>
               <p

--- a/src/views/widgets/drag/index.vue
+++ b/src/views/widgets/drag/index.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="page-content mb-5">
     <ElRow>
-      <ElCard shadow="never" class="w-75 mr-5 mb-7.5">
+      <ElCard class="w-75 mr-5 mb-7.5">
         <template #header>
           <span class="text-base font-bold">基础示例</span>
         </template>
@@ -19,7 +19,7 @@
         </template>
       </ElCard>
 
-      <ElCard shadow="never" class="w-75 mb-7.5">
+      <ElCard class="w-75 mb-7.5">
         <template #header>
           <span class="text-base font-bold">过渡动画</span>
         </template>
@@ -39,7 +39,7 @@
       </ElCard>
     </ElRow>
 
-    <ElCard shadow="never" class="mb-7.5">
+    <ElCard class="mb-7.5">
       <template #header>
         <span class="text-base font-bold">表格拖拽排序</span>
       </template>
@@ -53,7 +53,7 @@
       </template>
     </ElCard>
 
-    <ElCard shadow="never" class="mb-7.5">
+    <ElCard class="mb-7.5">
       <template #header>
         <span class="text-base font-bold">指定元素拖拽排序</span>
       </template>

--- a/src/views/widgets/qrcode/index.vue
+++ b/src/views/widgets/qrcode/index.vue
@@ -9,7 +9,7 @@
         v-for="preset in qrcodePresets"
         :key="preset.title"
       >
-        <ElCard class="mb-5" shadow="never">
+        <ElCard class="mb-5">
           <template #header>
             <div>
               <span class="text-base font-bold">{{ preset.title }}</span>

--- a/src/views/widgets/wang-editor/index.vue
+++ b/src/views/widgets/wang-editor/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="page-content mb-5">
     <!-- 完整工具栏编辑器 -->
-    <ElCard class="editor-card" shadow="never">
+    <ElCard class="editor-card">
       <template #header>
         <div class="card-header">
           <span>🛠️ 完整工具栏编辑器</span>
@@ -23,7 +23,7 @@
     </ElCard>
 
     <!-- 简化工具栏编辑器 -->
-    <ElCard class="editor-card" shadow="never">
+    <ElCard class="editor-card">
       <template #header>
         <div class="card-header">
           <span>✨ 简化工具栏编辑器</span>
@@ -45,7 +45,7 @@
     </ElCard>
 
     <!-- 内容对比预览 -->
-    <ElCard class="preview-card" shadow="never">
+    <ElCard class="preview-card">
       <template #header>
         <span>📖 内容预览对比</span>
       </template>
@@ -90,7 +90,7 @@
     </ElCard>
 
     <!-- 使用说明 -->
-    <ElCard class="usage-card" shadow="never">
+    <ElCard class="usage-card">
       <template #header>
         <span>📚 使用说明</span>
       </template>

--- a/src/views/widgets/watermark/index.vue
+++ b/src/views/widgets/watermark/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="page-content mb-5">
     <!-- 基础文字水印 -->
-    <ElCard class="mb-7.5" shadow="never">
+    <ElCard class="mb-7.5">
       <template #header>基础文字水印</template>
       <ElWatermark content="Art Design Pro" :font="{ color: 'rgba(128, 128, 128, 0.2)' }">
         <div style="height: 200px"></div>
@@ -9,7 +9,7 @@
     </ElCard>
 
     <!-- 多行文字水印 -->
-    <ElCard class="mb-7.5" shadow="never">
+    <ElCard class="mb-7.5">
       <template #header>多行文字水印</template>
       <ElWatermark
         :content="['Art Design Pro', '专注用户体验，视觉设计']"
@@ -20,7 +20,7 @@
     </ElCard>
 
     <!-- 图片水印 -->
-    <ElCard class="mb-7.5" shadow="never">
+    <ElCard class="mb-7.5">
       <template #header>图片水印</template>
       <ElWatermark :image="watermarkImage" :opacity="0.2" :width="80" :height="20">
         <div style="height: 200px"></div>
@@ -28,7 +28,7 @@
     </ElCard>
 
     <!-- 自定义样式水印 -->
-    <ElCard class="mb-7.5" shadow="never">
+    <ElCard class="mb-7.5">
       <template #header>自定义样式水印</template>
       <ElWatermark
         content="Art Design Pro"


### PR DESCRIPTION
- 在 ElConfigProvider 中添加 card.shadow: 'never' 全局配置
- 移除所有页面中 ElCard 组件的 shadow="never" 属性
- 统一卡片样式，减少重复代码