### PR TITLE
feat: enhance dark theme styles for image viewer component

### DIFF
--- a/src/assets/styles/core/dark.scss
+++ b/src/assets/styles/core/dark.scss
@@ -35,6 +35,40 @@ html.dark {
 }
 
 .dark {
+  .el-image-viewer__mask {
+    background: rgba(4, 6, 12, 0.9) !important;
+  }
+
+  .el-image-viewer__actions {
+    background: rgba(18, 20, 28, 0.88) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  }
+
+  .el-image-viewer__actions__inner {
+    color: var(--art-gray-900) !important;
+  }
+
+  .el-image-viewer__actions__inner .is-disabled {
+    color: var(--art-gray-500) !important;
+  }
+
+  .el-image-viewer__close,
+  .el-image-viewer__prev,
+  .el-image-viewer__next {
+    color: var(--art-gray-900) !important;
+    background: rgba(18, 20, 28, 0.88) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+  }
+
+  .el-image-viewer__close:hover,
+  .el-image-viewer__prev:hover,
+  .el-image-viewer__next:hover,
+  .el-image-viewer__actions__inner i:hover {
+    color: #ffffff !important;
+  }
+
   .page-content .article-list .item .left .outer > div {
     border-right-color: var(--dark-border-color) !important;
   }


### PR DESCRIPTION
文件预览适配深色模式

原样式：
<img width="1906" height="861" alt="img_v3_0211i_614bd2f4-7fd7-4c31-a4db-021948b01abg" src="https://github.com/user-attachments/assets/c0091bbf-999e-44e5-9d80-1ea9c49cb0fe" />
适配后样式：
<img width="1906" height="860" alt="img_v3_0211i_8ff29045-bc91-4baa-becd-96822482bf7g" src="https://github.com/user-attachments/assets/4c8a3799-9c76-445a-ba9f-4915d8331468" />