### PR TITLE
fix(layout): 修复双列菜单折叠撑高页面

### DIFF
--- a/src/components/core/layouts/art-menus/art-sidebar-menu/index.vue
+++ b/src/components/core/layouts/art-menus/art-sidebar-menu/index.vue
@@ -64,7 +64,10 @@
       v-show="menuList.length > 0"
       class="menu-left"
       :class="`menu-left-${getMenuTheme.theme} menu-left-${!menuOpen ? 'close' : 'open'}`"
-      :style="{ background: getMenuTheme.background }"
+      :style="{
+        background: getMenuTheme.background,
+        width: isDualMenuCollapsed ? MENU_CLOSE_WIDTH : undefined
+      }"
     >
       <!-- Logo、系统名称 -->
       <div
@@ -170,6 +173,7 @@
     () => menuType.value === MenuTypeEnum.LEFT || menuType.value === MenuTypeEnum.TOP_LEFT
   )
   const isDualMenu = computed(() => menuType.value === MenuTypeEnum.DUAL_MENU)
+  const isDualMenuCollapsed = computed(() => isDualMenu.value && !menuOpen.value)
 
   // 移动端屏幕判断（使用 computed 避免重复计算）
   const isMobileScreen = computed(() => width.value < MOBILE_BREAKPOINT)
@@ -210,10 +214,21 @@
 
   // 双列菜单收起时的滚动条样式
   const scrollbarStyle = computed(() => {
-    const isCollapsed = isDualMenu.value && !menuOpen.value
+    if (isDualMenuCollapsed.value) {
+      return {
+        position: 'absolute',
+        top: '60px',
+        right: 0,
+        left: 0,
+        height: 'calc(100% - 10px)',
+        transform: 'translateY(-50px)',
+        transition: 'transform 0.3s ease'
+      }
+    }
+
     return {
-      transform: isCollapsed ? 'translateY(-50px)' : 'translateY(0)',
-      height: isCollapsed ? 'calc(100% + 50px)' : 'calc(100% - 60px)',
+      transform: 'translateY(0)',
+      height: 'calc(100% - 60px)',
       transition: 'transform 0.3s ease'
     }
   })


### PR DESCRIPTION
## 改动背景/原因

双列菜单在一级菜单文本折叠且右侧菜单也折叠时，右侧菜单滚动区会把页面高度撑高，导致控制台页面底部出现额外空白和页面滚动。

## 主要改动内容

- 保留原有菜单背景样式绑定，仅在双列右侧菜单折叠时补充收起宽度
- 复用双列菜单折叠态判断，避免影响其他菜单布局
- 将折叠态菜单滚动区改为绝对定位并保留原来的向上偏移视觉效果，避免参与文档流撑高页面

## 测试情况

- 通过 `pnpm build`
- 本地在 `http://127.0.0.1:5173/` 验证双列菜单两列同时折叠时，页面底部不再出现额外空白，左右两列折叠菜单正常显示

## 注意事项

无