### PR TITLE
fix(layout): 修复缓存路由切换时页面布局错位

### DIFF
--- a/src/components/core/layouts/art-page-content/index.vue
+++ b/src/components/core/layouts/art-page-content/index.vue
@@ -15,26 +15,12 @@
     </div>
 
     <RouterView v-if="isRefresh" v-slot="{ Component, route }" :style="contentStyle">
-      <!-- 缓存路由动画 -->
+      <!-- 统一处理缓存与非缓存路由动画，避免两个 Transition 同时参与文档流 -->
       <Transition :name="showTransitionMask ? '' : actualTransition" mode="out-in" appear>
-        <KeepAlive :max="10" :exclude="keepAliveExclude">
-          <component
-            class="art-page-view"
-            :is="Component"
-            :key="route.path"
-            v-if="route.meta.keepAlive"
-          />
+        <!-- KeepAlive 始终挂载，非缓存路由通过 exclude 动态处理 -->
+        <KeepAlive :max="10" :exclude="routeCacheExclude">
+          <component class="art-page-view" :is="Component" :key="route.path" />
         </KeepAlive>
-      </Transition>
-
-      <!-- 非缓存路由动画 -->
-      <Transition :name="showTransitionMask ? '' : actualTransition" mode="out-in" appear>
-        <component
-          class="art-page-view"
-          :is="Component"
-          :key="route.path"
-          v-if="!route.meta.keepAlive"
-        />
       </Transition>
     </RouterView>
 
@@ -60,6 +46,15 @@
   const { containerMinHeight } = useAutoLayoutHeight()
   const { pageTransition, containerWidth, refresh } = storeToRefs(useSettingStore())
   const { keepAliveExclude } = storeToRefs(useWorktabStore())
+
+  // 当前非缓存路由动态排除，保持原有的页面缓存策略
+  const routeCacheExclude = computed(() => {
+    const exclude = new Set(keepAliveExclude.value)
+    if (!route.meta.keepAlive && typeof route.name === 'string') {
+      exclude.add(route.name)
+    }
+    return [...exclude]
+  })
 
   const isRefresh = shallowRef(true)
   const isOpenRouteInfo = import.meta.env.VITE_OPEN_ROUTE_INFO


### PR DESCRIPTION
## 问题描述

页面内容布局中，缓存路由和非缓存路由分别使用了两个独立的 `Transition`。

当缓存路由与非缓存路由之间切换时，两个 `Transition` 会同时执行动画。由于 `mode="out-in"` 只能协调同一个 `Transition` 内部的组件，无法协调两个独立的 `Transition`，导致旧页面离场和新页面入场期间同时处于正常文档流中。

因此，新页面中的 `ArtBasicBanner` 等内容可能暂时显示在旧页面内容底部，动画结束后才恢复到正确位置。

## 复现步骤

1. 进入缓存路由，例如 `/system/user`。
2. 切换到非缓存路由，例如 `/dashboard/ecommerce`。
3. 在两个页面之间快速来回切换。
4. 观察页面过渡动画期间的内容位置。

## 修复方案

将缓存路由和非缓存路由统一放入同一个 `Transition` 中，并保持 `KeepAlive` 始终挂载。

对于 `keepAlive: false` 的当前路由，动态加入 `KeepAlive` 的 `exclude` 列表，从而保留原有的路由缓存策略。

这样所有页面切换都由同一个 `mode="out-in"` 统一协调，避免新旧页面同时参与文档流。

## 验证结果

- 缓存路由仍能正常缓存。
- 非缓存路由不会被缓存。
- 页面切换期间不再出现新页面内容显示在旧页面底部的问题。
- 类型检查、ESLint、Prettier、Stylelint 和生产构建均已通过。